### PR TITLE
Remove m2crypto from "install" lines for dnf-plugin-spacewalk

### DIFF
--- a/RegisteringClients.md
+++ b/RegisteringClients.md
@@ -25,7 +25,7 @@ If you are looking to register client systems to Spacewalk Nightly, more details
 > **Note:**
 > `rhnreg_ks` is used for registration of clients to Spacewalk. If you need to re-register a client to your Spacewalk server or change registration from one environment or server to another Spacewalk server then use the "--force" flag with `rhnreg_ks`, otherwise there is no need to use "--force".
 
-### Fedora
+### Fedora, Red Hat Enterprise Linux/Scientific Linux/CentOS 8
 
 1. Install the Spacewalk client yum repository
       ```
@@ -34,7 +34,7 @@ If you are looking to register client systems to Spacewalk Nightly, more details
 
 2. Install client packages
       ```
-      dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto dnf-plugin-spacewalk
+      dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd dnf-plugin-spacewalk
       ```
 
 3. Install Spacewalk's CA certificate on the server to enable SSL communication (change rpm version in this command if needed)     

--- a/RegisteringClients210.md
+++ b/RegisteringClients210.md
@@ -25,7 +25,7 @@ If you are looking to register client systems to Spacewalk Nightly, more details
 > **Note:**
 > `rhnreg_ks` is used for registration of clients to Spacewalk. If you need to re-register a client to your Spacewalk server or change registration from one environment or server to another Spacewalk server then use the "--force" flag with `rhnreg_ks`, otherwise there is no need to use "--force".
 
-### Fedora
+### Fedora, Red Hat Enterprise Linux/Scientific Linux/CentOS 8
 
 1. Install the Spacewalk client yum repository
       ```
@@ -34,7 +34,7 @@ If you are looking to register client systems to Spacewalk Nightly, more details
 
 2. Install client packages
       ```
-      dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto dnf-plugin-spacewalk
+      dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd dnf-plugin-spacewalk
       ```
 
 3. Install Spacewalk's CA certificate on the server to enable SSL communication (change rpm version in this command if needed)     

--- a/RegisteringClients24.md
+++ b/RegisteringClients24.md
@@ -38,7 +38,7 @@ Instructions for registering client systems you wish to manage with Spacewalk 2.
        }}}
         * For Fedora 22:
        {{{
-    # dnf install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto dnf-plugin-spacewalk
+    # dnf install rhn-client-tools rhn-check rhn-setup rhnsd dnf-plugin-spacewalk
        }}}
      3. Install Spacewalk's CA certificate on the server to enable SSL communication (change rpm version in this command if needed)
     {{{

--- a/RegisteringClients25.md
+++ b/RegisteringClients25.md
@@ -35,7 +35,7 @@ Instructions for registering client systems you wish to manage with Spacewalk 2.
  2. Install client packages
     * For Fedora 22 and Fedora 23:
    
-    # dnf install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto dnf-plugin-spacewalk
+    # dnf install rhn-client-tools rhn-check rhn-setup rhnsd dnf-plugin-spacewalk
        }}}
      3. Install Spacewalk's CA certificate on the server to enable SSL communication (change rpm version in this command if needed)
     {{{

--- a/RegisteringClients26.md
+++ b/RegisteringClients26.md
@@ -35,7 +35,7 @@ Registering Clients
        
 2. Install client packages
       ```
-      # dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto dnf-plugin-spacewalk
+      # dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd dnf-plugin-spacewalk
       ```
 
 3. Install Spacewalk's CA certificate on the server to enable SSL communication (change rpm version in this command if needed)     

--- a/RegisteringClientsNightly.md
+++ b/RegisteringClientsNightly.md
@@ -12,7 +12,7 @@ Registering Clients
 > **Note:**
 > `rhnreg_ks` is used for registration of clients to Spacewalk. If you need to re-register a client to your Spacewalk server or change registration from one environment or server to another Spacewalk server then use the "--force" flag with `rhnreg_ks`, otherwise there is no need to use "--force".
 
-### Fedora
+### Fedora, Red Hat Enterprise Linux/Scientific Linux/CentOS 8
 
 1. Install the Spacewalk client yum repository
       ```
@@ -21,7 +21,7 @@ Registering Clients
 
 2. Install client packages
       ```
-      dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto dnf-plugin-spacewalk
+      dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd dnf-plugin-spacewalk
       ```
 
 3. Install Spacewalk's CA certificate on the server to enable SSL communication (change rpm version in this command if needed)     


### PR DESCRIPTION
`m2crypto` was never a requirement for `dnf-plugin-spacewalk`, only `yum-rhn-plugin` requires it.

What is more, `m2crypto` is not available on CentOS 8:

```
# dnf -y install rhn-client-tools rhn-check rhn-setup rhnsd m2crypto dnf-plugin-spacewalk
Package rhn-client-tools-2.8.16-13.module_el8.1.0+211+ad6c0bc7.x86_64 is already installed.
Package rhn-check-2.8.16-13.module_el8.1.0+211+ad6c0bc7.x86_64 is already installed.
Package rhn-setup-2.8.16-13.module_el8.1.0+211+ad6c0bc7.x86_64 is already installed.
Package rhnsd-5.0.35-3.module_el8.1.0+211+ad6c0bc7.x86_64 is already installed.
No match for argument: m2crypto
Package dnf-plugin-spacewalk-2.8.5-11.module_el8.1.0+211+ad6c0bc7.noarch is already installed.
Error: Unable to find a match: m2crypto
```